### PR TITLE
Make tests self-contained and suppress messages

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,11 +1,3 @@
-# This file is part of the standard setup for testthat.
-# It is recommended that you do not modify it.
-#
-# Where should you do additional test configuration?
-# Learn more about the roles of various files in:
-# * https://r-pkgs.org/tests.html
-# * https://testthat.r-lib.org/reference/test_package.html#special-files
-
 library(testthat)
 library(boxly)
 

--- a/tests/testthat/test-independant-testing-prepare_boxly.R
+++ b/tests/testthat/test-independant-testing-prepare_boxly.R
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-meta <- meta_boxly(
-  boxly_adsl,
-  boxly_adlb,
-  population_term = "apat",
-  observation_term = "wk12",
-  observation_subset = AVISITN <= 12 & !is.na(CHG)
-)
-
 test_that("Its class is 'outdata'", {
-  output <- prepare_boxly(meta)
+  meta <- meta_boxly(
+    boxly_adsl,
+    boxly_adlb,
+    population_term = "apat",
+    observation_term = "wk12",
+    observation_subset = AVISITN <= 12 & !is.na(CHG)
+  )
+
+  output <- suppressMessages(prepare_boxly(meta))
 
   expect_equal(class(output), "outdata")
   expect_equal(output$population, "apat")

--- a/tests/testthat/test-independent-testing-boxly.R
+++ b/tests/testthat/test-independent-testing-boxly.R
@@ -16,18 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-meta <- meta_boxly(
-  boxly_adsl,
-  boxly_adlb,
-  population_term = "apat",
-  observation_term = "wk12",
-  observation_subset = AVISITN <= 12 & !is.na(CHG)
-)
-
-x <- prepare_boxly(meta)
-
 test_that("validation of boxly plot Case 1", {
+  meta <- meta_boxly(
+    boxly_adsl,
+    boxly_adlb,
+    population_term = "apat",
+    observation_term = "wk12",
+    observation_subset = AVISITN <= 12 & !is.na(CHG)
+  )
+
+  x <- suppressMessages(prepare_boxly(meta))
+
   y <- boxly(x,
     color = c("black", "grey", "red"),
     hover_summary_var = c("n", "min", "q1", "median", "mean", "q3", "max"),
@@ -57,8 +56,17 @@ test_that("validation of boxly plot Case 1", {
   expect_equal(baselabel, "Change from Baseline: ")
 })
 
-
 test_that("validation of boxly plot Case 2", {
+  meta <- meta_boxly(
+    boxly_adsl,
+    boxly_adlb,
+    population_term = "apat",
+    observation_term = "wk12",
+    observation_subset = AVISITN <= 12 & !is.na(CHG)
+  )
+
+  x <- suppressMessages(prepare_boxly(meta))
+
   y <- boxly(x,
     color = c("green", "yellow", "red"),
     hover_summary_var = c("n", "min", "q1", "mean", "q3"),

--- a/tests/testthat/test-independent-testing-meta_boxly.R
+++ b/tests/testthat/test-independent-testing-meta_boxly.R
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-x <- meta_boxly(
-  boxly_adsl,
-  boxly_adlb,
-  population_term = "apat",
-  observation_term = "wk12",
-  observation_subset = AVISITN <= 12 & !is.na(CHG)
-)
-
 test_that("meta_boxly() structure", {
+  x <- meta_boxly(
+    boxly_adsl,
+    boxly_adlb,
+    population_term = "apat",
+    observation_term = "wk12",
+    observation_subset = AVISITN <= 12 & !is.na(CHG)
+  )
+
   expect_equal(class(x), "meta_adam")
   expect_equal(class(x$data_population), "data.frame")
   expect_equal(class(x$data_observation), c("tbl_df", "tbl", "data.frame"))


### PR DESCRIPTION
As recommended by [R Packages](https://r-pkgs.org/testing-design.html), this PR makes all tests self-contained by moving the top-level logic that used to have awkward "test file scope" into individual tests. Now all test files only contain `test_that()` blocks.

I also used `suppressMessages()` to suppress the messages from the `prepare_boxly()` calls in tests.